### PR TITLE
Add TableTraits.jl support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# ElectronDisplay.jl v0.7.0 Release Notes
+* Add support for TableTraits.jl sources
+
 # ElectronDisplay.jl v0.6.0 Release Notes
 * Update vega and vega-embed
 * Add support for "text/html" and "text/markdown" MIME types

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,5 @@
 julia 0.7
 Electron 0.2.0
+TableTraits 0.4.1
+TableShowUtils 0.2.3
+IteratorInterfaceExtensions 0.1.1


### PR DESCRIPTION
@tkf This slightly extends your work on the grid: it should now work for any source that implements the [TableTraits.jl](https://github.com/queryverse/TableTraits.jl) interface. So DataFrames, IndexedTables, JuliaDB etc. should in theory all work now (I only tested DataFrame).