### PR TITLE
Add CONFIG.focus flag

### DIFF
--- a/src/ElectronDisplay.jl
+++ b/src/ElectronDisplay.jl
@@ -49,15 +49,17 @@ function _getglobalwindow()
     return _window[]
 end
 
-function displayhtml(payload; show=CONFIG.focus, kwargs...)
+function displayhtml(payload; options::Dict=Dict{String,Any}())
     if CONFIG.single_window
         w = _getglobalwindow()
         load(w, payload)
-        showfun = show ? "show" : "showInactive"
+        showfun = get(options, "show", CONFIG.focus) ? "show" : "showInactive"
         run(w.app, "BrowserWindow.fromId($(w.id)).$showfun()")
         return w
     else
-        return Electron.Window(payload; show=show, kwargs...)
+        options = Dict{String,Any}(options)
+        get!(options, "show", CONFIG.focus)
+        return Electron.Window(payload; options=options)
     end
 end
 

--- a/src/ElectronDisplay.jl
+++ b/src/ElectronDisplay.jl
@@ -15,6 +15,7 @@ electron_showable(m, x) =
 mutable struct ElectronDisplayConfig
     showable
     single_window::Bool
+    focus::Bool
 end
 
 """
@@ -31,8 +32,11 @@ Configuration for ElectronDisplay.
 * `single_window::Bool = false`: If `true`, reuse existing window for
   displaying a new content.  If `false` (default), create a new window
   for each display.
+
+* `focus::Bool = true`: Focus the Electron window on `display` if `true`
+  (default).
 """
-const CONFIG = ElectronDisplayConfig(electron_showable, false)
+const CONFIG = ElectronDisplayConfig(electron_showable, false, true)
 
 const _window = Ref{Window}()
 
@@ -45,14 +49,15 @@ function _getglobalwindow()
     return _window[]
 end
 
-function displayhtml(payload; kwargs...)
+function displayhtml(payload; show=CONFIG.focus, kwargs...)
     if CONFIG.single_window
         w = _getglobalwindow()
         load(w, payload)
-        run(w.app, "BrowserWindow.fromId($(w.id)).show()")
+        showfun = show ? "show" : "showInactive"
+        run(w.app, "BrowserWindow.fromId($(w.id)).$showfun()")
         return w
     else
-        return Electron.Window(payload; kwargs...)
+        return Electron.Window(payload; show=show, kwargs...)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,13 @@ f2 = display(p2)
 
 @test f2 === f   # Window is reused
 
-@test electrondisplay(dataset("cars")) isa Electron.Window
-@test electrondisplay(@doc reduce) isa Electron.Window
+@testset "smoke test: single_window=$single_window focus=$focus " for
+        single_window in [false, true],
+        focus in [false, true]
+    ElectronDisplay.CONFIG.single_window = single_window
+    ElectronDisplay.CONFIG.focus = focus
+    @test electrondisplay(dataset("cars")) isa Electron.Window
+    @test electrondisplay(@doc reduce) isa Electron.Window
+end
 
 end


### PR DESCRIPTION
When using `CONFIG.single_window`, I find it useful to update ElectronDisplay window without changing focus from REPL.  It can be done by `CONFIG.focus = false` with this PR.