### PR TITLE
Remove a confusing `using Markdown` from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,5 @@ ElectronDisplay.CONFIG.single_window = true
 To control objects to be handled by `ElectronDisplay`, you can set `ElectronDisplay.CONFIG.showable`.  By default, `ElectronDisplay` does not show markdown, HTML, and `application/vnd.dataresource+json` output.  To show everything in `ElectronDisplay` whenever it's supported, you can use:
 
 ````julia
-using Markdown
 ElectronDisplay.CONFIG.showable = showable
 ````


### PR DESCRIPTION
This is a line added in f93907b960397219f70362f10d2595f68f258867 that I forgot to remove in 99e9f8985451ad736a9906e2e961a28d18bf72c0 (both from #8).