### PR TITLE
Prioritize ElectronDisplay over REPL

### DIFF
--- a/src/ElectronDisplay.jl
+++ b/src/ElectronDisplay.jl
@@ -394,8 +394,23 @@ function electrondisplay(x)
     end
 end
 
+"""
+    afterreplinit(f)
+
+Like `atreplinit` but triggers `f` even after REPL is initialized when
+it is called.
+"""
+function afterreplinit(f)
+    # See: https://github.com/JuliaLang/Pkg.jl/blob/v1.0.2/src/Pkg.jl#L338
+    if isdefined(Base, :active_repl)
+        f()
+    else
+        atreplinit(_ -> f())
+    end
+end
+
 function __init__()
-    atreplinit() do _repl
+    afterreplinit() do
         Base.Multimedia.pushdisplay(ElectronDisplayType())
     end
 end

--- a/src/ElectronDisplay.jl
+++ b/src/ElectronDisplay.jl
@@ -395,7 +395,9 @@ function electrondisplay(x)
 end
 
 function __init__()
-    Base.Multimedia.pushdisplay(ElectronDisplayType())
+    atreplinit() do _repl
+        Base.Multimedia.pushdisplay(ElectronDisplayType())
+    end
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,12 @@ using Electron
 using VegaDatasets
 using Test
 
+# Register ElectronDisplay in case this Julia session is started
+# without RPEL.
+if ElectronDisplay.ElectronDisplayType() ∉ Base.Multimedia.displays
+    Base.Multimedia.pushdisplay(ElectronDisplay.ElectronDisplayType())
+end
+
 @testset "ElectronDisplay" begin
 
 p1 = plot(y=[1,2,3])


### PR DESCRIPTION
Without this patch, when ElectronDisplay is imported before REPL is initialized, it looses to REPL's display.  We can prioritize ElectronDisplay over REPL by calling `pushdisplay` in `atreplinit`.

Before:

```console
$ cat ~/.julia/config/startup.jl
using ElectronDisplay

$ julia -q
julia> typeof.(Base.Multimedia.displays)
3-element Array{DataType,1}:
 TextDisplay
 ElectronDisplay.ElectronDisplayType
 REPL.REPLDisplay{REPL.LineEditREPL}
```

After:

```console
$ julia -q
julia> typeof.(Base.Multimedia.displays)
3-element Array{DataType,1}:
 TextDisplay
 REPL.REPLDisplay{REPL.LineEditREPL}
 ElectronDisplay.ElectronDisplayType
```
