### PR TITLE
Use ConstructionBase.setproperties instead of hand-coding setconfig

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.8.2-DEV"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 Electron = "a1bb12fb-d4d1-54b4-b10a-ee7951ef7ad3"
 TableShowUtils = "5e66a065-1f0a-5976-b372-e0b8c017ca10"
 IteratorInterfaceExtensions = "82899510-4779-5014-852e-03e436cf321d"

--- a/src/ElectronDisplay.jl
+++ b/src/ElectronDisplay.jl
@@ -3,6 +3,7 @@ module ElectronDisplay
 export electrondisplay
 
 using Electron, Base64, Markdown
+using ConstructionBase: setproperties
 
 import IteratorInterfaceExtensions, TableTraits, TableShowUtils
 
@@ -12,29 +13,12 @@ Base.@kwdef mutable struct ElectronDisplayConfig
     focus::Bool = true
 end
 
-"""
-    setconfig(config; kwargs...)
-
-Update a copy of `config` based on `kwargs`.
-"""
-setconfig(
-    config::ElectronDisplayConfig;
-    showable = config.showable,
-    single_window::Bool = config.single_window,
-    focus::Bool = config.focus,
-) =
-    ElectronDisplayConfig(
-        showable = showable,
-        single_window = single_window,
-        focus = focus,
-    )
-
 struct ElectronDisplayType <: Base.AbstractDisplay
     config::ElectronDisplayConfig
 end
 
 ElectronDisplayType() = ElectronDisplayType(CONFIG)
-newdisplay(; config...) = ElectronDisplayType(setconfig(CONFIG; config...))
+newdisplay(; config...) = ElectronDisplayType(setproperties(CONFIG; config...))
 
 electron_showable(m, x) =
     m ∉ ("application/vnd.dataresource+json", "text/html", "text/markdown") &&


### PR DESCRIPTION
I suggest using [`ConstructionBase.setproperties`](https://juliaobjects.github.io/ConstructionBase.jl/dev/#ConstructionBase.setproperties) instead of the manually coded `setconfig`.