### PR TITLE
Add `window` argument to `electrondisplay`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,11 @@ eldt = ElectronDisplay.ElectronDisplayType()
 @test electrondisplay(vg4) isa Electron.Window
 @test electrondisplay(vg5) isa Electron.Window
 
+@testset "explicit window" begin
+    @test electrondisplay(f, p1) === f
+    @test electrondisplay(f, "text/html", p1) === f
+end
+
 @test_logs(
     (:warn, r"The size of JSON representation.*exceeds.*max_json_bytes"),
     electrondisplay(vl3png; max_json_bytes=-1)::Electron.Window


### PR DESCRIPTION
This PR adds new signatures `electrondisplay(window, [mime,] x)` to `electrondisplay`. It lets you display things in pre-existing `Electron.Window`.