### PR TITLE
Update FilePaths.jl bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ TableTraits = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
 
 [compat]
 Electron = "0.2, 0.3, 0.4, 1, 2, 3.0"
-FilePaths = "0.8"
+FilePaths = "0.8.1"
 IteratorInterfaceExtensions = "0.1.1, 1"
 JSON = "0.20, 0.21"
 TableShowUtils = "0.2.3"

--- a/src/ElectronDisplay.jl
+++ b/src/ElectronDisplay.jl
@@ -9,7 +9,7 @@ import IteratorInterfaceExtensions, TableTraits, TableShowUtils
 using FilePaths
 
 asset(url...) = replace(normpath(joinpath(@__DIR__, "..", "assets", url...)), "\\" => "/")
-react_html_url = join(@__PATH__, "..", "assets", "plotgallery", "index.html")
+react_html_url = joinpath(@__PATH__, "..", "assets", "plotgallery", "index.html")
 
 Base.@kwdef mutable struct ElectronDisplayConfig
     showable = electron_showable


### PR DESCRIPTION
Fixes https://github.com/queryverse/ElectronDisplay.jl/issues/79. Or at least I hope.

I think FilePaths.jl v0.8.1 should guaranty that we get a version of FilePathsBase.jl that is based on `joinpath`.

But I can't do anything about the version that has already been released that specifies compat as FilePaths.jl 0.8... That is a real problem, because with that compat entry one can get either FilePathsBase 0.6 or 0.9, and those have breaking differences... So I think the core problem is that FilePaths.jl 0.8.1 should really have been FilePaths.jl 0.9...